### PR TITLE
1、新增心知天气 API 调用示例 Objective-C 版本。 注：签名验证方式

### DIFF
--- a/oc/HmacSha1Tool.h
+++ b/oc/HmacSha1Tool.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+@interface HmacSha1Tool : NSObject
+
++ (NSString *)HmacSha1Key:(NSString *)key data:(NSString *)data;
+@end

--- a/oc/HmacSha1Tool.m
+++ b/oc/HmacSha1Tool.m
@@ -1,0 +1,34 @@
+#import "HmacSha1Tool.h"
+#import <CommonCrypto/CommonHMAC.h>
+@implementation HmacSha1Tool
+
+/**
+ 通过 HMAC-SHA1，对请求参数字符串进行加密，得到一个签名字符串。
+
+ @param key 你的 API 密钥
+ @param data 请求参数字符串
+ @return 签名字符串 sig
+ */
++ (NSString *)HmacSha1Key:(NSString *)key data:(NSString *)data {
+    const char *cKey  = [key cStringUsingEncoding:NSASCIIStringEncoding];
+    const char *cData = [data cStringUsingEncoding:NSASCIIStringEncoding];
+
+    // HmacSHA1 加密
+    unsigned char cHMAC[CC_SHA1_DIGEST_LENGTH];
+    CCHmac(kCCHmacAlgSHA1, cKey, strlen(cKey), cData, strlen(cData), cHMAC);
+    NSData *HMAC = [[NSData alloc] initWithBytes:cHMAC
+                                          length:sizeof(cHMAC)];
+
+    //将加密结果进行一次 BASE64 编码。
+    NSString *hash = [HMAC base64EncodedStringWithOptions:0];
+
+    //将 BASE64 编码结果做一个 urlencode
+    NSString *charactersToEscape = @"?!@#$^&%*+,:;='\"`<>()[]{}/\\| ";
+    NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
+    NSString *encodedUrl = [hash stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+
+    //得到签名 sig
+    return encodedUrl;
+}
+
+@end

--- a/oc/README.md
+++ b/oc/README.md
@@ -1,0 +1,8 @@
+# 心知天气 API 调用示例 Objective-C
+
+#### Demo 运行方法
+Xcode 新建一个项目，将`HmacSha1Tool.h`, `HmacSha1Tool.m`, `ViewController.h`, `ViewController.m`四个文件拷贝到项目中（`ViewController.h`, `ViewController.m`直接替换），直接运行即可查看天气实况，如果想查看心知天气其他 API，可在 `ViewController.m` 文件中把 `viewDidLoad` 方法里面的`TIANQI_NOW_WEATHER_URL`替换为你想查看的URL即可。
+
+
+#### 注意
+本项目未做默认值为空校验，实际开发需做好校验。

--- a/oc/README.md
+++ b/oc/README.md
@@ -1,8 +1,10 @@
 # 心知天气 API 调用示例 Objective-C
 
-#### Demo 运行方法
-Xcode 新建一个项目，将`HmacSha1Tool.h`, `HmacSha1Tool.m`, `ViewController.h`, `ViewController.m`四个文件拷贝到项目中（`ViewController.h`, `ViewController.m`直接替换），直接运行即可查看天气实况，如果想查看心知天气其他 API，可在 `ViewController.m` 文件中把 `viewDidLoad` 方法里面的`TIANQI_NOW_WEATHER_URL`替换为你想查看的URL即可。
+## Demo 运行方法
 
+Xcode 新建一个项目，将 `HmacSha1Tool.h`, `HmacSha1Tool.m`, `ViewController.h`, `ViewController.m` 四个文件拷贝到项目中（`ViewController.h`, `ViewController.m` 直接替换），直接运行即可查看天气实况，如果想查看心知天气其他 API，可在 `ViewController.m` 文件中把 `viewDidLoad` 方法里面的 `TIANQI_NOW_WEATHER_URL` 替换为你想查看的URL即可。
 
-#### 注意
-本项目未做默认值为空校验，实际开发需做好校验。
+## 注意
+
+- 本项目未做默认值为空校验，实际开发需做好校验。
+- 仅做开发参考使用，不建议在生产环境下暴露 key

--- a/oc/ViewController.h
+++ b/oc/ViewController.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/oc/ViewController.m
+++ b/oc/ViewController.m
@@ -1,0 +1,76 @@
+#import "ViewController.h"
+#import "HmacSha1Tool.h"
+
+@interface ViewController ()
+@end
+
+@implementation ViewController
+
+#pragma mark - API KEY / USER ID
+
+static NSString *TIANQI_API_SECRET_KEY = @"xkojmyi74gj0kjgi";   // YOUR API KEY
+static NSString *TIANQI_API_USER_ID = @"U0E4A68FBD";            // YOUR USER ID
+
+#pragma mark - 天气、生活、位置接口（这里只测试了免费接口，付费接口未做测试）
+
+//---------------------- 天气 ----------------------
+static NSString *TIANQI_DAILY_WEATHER_URL = @"https://api.seniverse.com/v3/weather/daily.json";     //逐日天气预报和昨日天气 URL
+static NSString *TIANQI_NOW_WEATHER_URL = @"https://api.seniverse.com/v3/weather/now.json";         //天气实况 URL
+
+//---------------------- 生活 ----------------------
+static NSString *TIANQI_LIFE_SUGGESTION_URL = @"https://api.seniverse.com/v3/life/suggestion.json"; //生活指数 URL
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // 创建 session 对象
+    NSURLSession *session = [NSURLSession sharedSession];
+    NSString *urlStr = [self fetchWeatherWithURL:TIANQI_LIFE_SUGGESTION_URL ttl:@30 Location:@"shanghai" language:@"zh-Hans" unit:@"c" start:@"1" days:@"1"];
+    NSURL *url = [NSURL URLWithString:urlStr];
+
+    // 通过 URL 初始化 task,在 block 内部可以直接对返回的数据进行处理
+    NSURLSessionTask *task = [session dataTaskWithURL:url
+                                    completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                        NSLog(@"%@", [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil]);
+                                    }];
+
+    // 启动任务
+    [task resume];
+}
+
+/**
+ 配置带请求参数的 url 地址。
+
+ @param url 需要请求的 url 地址。 例如：获取指定城市的天气实况 url 为 TIANQI_NOW_WEATHER_URL
+ @param ttl 签名失效时间(可选)，默认有效期为 1800 秒（30分钟）
+ @param location 所查询的位置
+ @param language 语言(可选)。 默认值：zh-Hans
+ @param unit 单位 (可选)。默认值：c
+ @param start 起始时间 (可选)。默认值：0
+ @param days 天数 (可选)。 默认为你的权限允许的最多天数
+ @return return 带请求参数的 url 地址
+ */
+- (NSString *)fetchWeatherWithURL:(NSString *)url ttl:(NSNumber *)ttl Location:(NSString *)location
+                         language:(NSString *)language unit:(NSString *)unit
+                            start:(NSString *)start days:(NSString *)days{
+    NSString *timestamp = [NSString stringWithFormat:@"%.0ld",time(NULL)];
+    NSString *params = [NSString stringWithFormat:@"ts=%@&ttl=%@&uid=%@", timestamp, ttl, TIANQI_API_USER_ID];
+    NSString *signature =  [self getSigntureWithParams:params];
+
+    NSString *urlStr = [NSString stringWithFormat:@"%@?%@&sig=%@&location=%@&language=%@&unit=%@&start=%@&days=%@",
+                        url, params, signature, location, language, unit, start, days];
+    return urlStr;
+}
+
+/**
+ 获得签名字符串，关于如何使用签名验证方式，详情见 https://www.seniverse.com/doc#sign
+
+ @param params 验证参数字符串
+ @return signature HMAC-SHA1 加密后得到的签名字符串
+ */
+- (NSString *)getSigntureWithParams:(NSString *)params{
+    NSString *signature = [HmacSha1Tool HmacSha1Key:TIANQI_API_SECRET_KEY data:params];
+    return signature;
+}
+
+@end


### PR DESCRIPTION
1、pull request 原因
网上想找一个稳定的天气 api，发现心知天气 api 比较不错，查看了下没有 OC 版本示例 ，就自己写了个望方便其他开发者，您看看还符合要求吗？
如有需要，可以后面补个Swift版本。